### PR TITLE
Add failfast option, replace exp/slog package with stdlib, add github errors output

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -49,8 +49,8 @@ var _ = rootFS.WriteFile("prove7/subdir/.test-file!!", []byte(""), 0777)
 func TestDirEmpty(t *testing.T) {
 	synta := synta.MustSynta(`useless = a|dir1
 > useless.useless`)
-	err := CheckDir(&synta, rootFS, "dir1", &Options{true, true, false})
-	assert.Nil(t, err)
+	err := CheckDir(&synta, rootFS, "dir1", &Options{true, true, false, false})
+	assert.Len(t, err, 0)
 }
 
 func TestDirOneFileCorrect(t *testing.T) {
@@ -59,8 +59,8 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove", &Options{true, true, false})
-	assert.Nil(t, err)
+	err := CheckDir(&synta, rootFS, "prove", &Options{true, true, false, false})
+	assert.Len(t, err, 0)
 }
 
 func TestDirOneFileNotCorrect(t *testing.T) {
@@ -69,8 +69,8 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove2", &Options{true, true, false})
-	assert.NotNil(t, err)
+	err := CheckDir(&synta, rootFS, "prove2", &Options{true, true, false, false})
+	assert.Len(t, err, 1)
 }
 
 func TestDirFileCorrectAndNotCorrect(t *testing.T) {
@@ -79,9 +79,9 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove3", &Options{true, true, false})
-	assert.NotNil(t, err)
-	matchErr := err.(RegexMatchError)
+	err := CheckDir(&synta, rootFS, "prove3", &Options{true, true, false, false})
+	assert.Len(t, err, 2)
+	matchErr := err[0].(RegexMatchError)
 	assert.Equal(t, "basi___c123.txt", matchErr.Filename)
 }
 
@@ -91,8 +91,8 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove4", &Options{true, true, false})
-	assert.Nil(t, err)
+	err := CheckDir(&synta, rootFS, "prove4", &Options{true, true, false, false})
+	assert.Len(t, err, 0)
 }
 
 func TestDirRecursiveWithNotCorrectDirName(t *testing.T) {
@@ -101,7 +101,7 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove5", &Options{true, true, false})
+	err := CheckDir(&synta, rootFS, "prove5", &Options{true, true, false, false})
 	assert.NotNil(t, err)
 }
 
@@ -111,8 +111,8 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove6", &Options{true, true, false})
-	assert.Nil(t, err)
+	err := CheckDir(&synta, rootFS, "prove6", &Options{true, true, false, false})
+	assert.Len(t, err, 0)
 }
 
 func TestDirIgnoreDots(t *testing.T) {
@@ -121,9 +121,10 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove7", &Options{false, true, true})
-	assert.Nil(t, err)
-	err = CheckDir(&synta, rootFS, "prove7", &Options{false, true, false})
+	err := CheckDir(&synta, rootFS, "prove7", &Options{false, true, true, false})
+	assert.Len(t, err, 0)
+
+	err = CheckDir(&synta, rootFS, "prove7", &Options{false, true, false, false})
 	assert.NotNil(t, err)
 }
 
@@ -133,15 +134,18 @@ ext = pdf|txt|tex|md
 > word.ext`
 
 	synta := synta.MustSynta(input)
-	err := CheckDir(&synta, rootFS, "prove7", &Options{true, true, true})
-	assert.Nil(t, err)
-	err = CheckDir(&synta, rootFS, "prove7", &Options{false, true, true})
-	assert.Nil(t, err)
-	err = CheckDir(&synta, rootFS, "prove7", &Options{true, true, false})
+
+	err := CheckDir(&synta, rootFS, "prove7", &Options{true, true, true, false})
+	assert.Len(t, err, 0)
+
+	err = CheckDir(&synta, rootFS, "prove7", &Options{false, true, true, false})
+	assert.Len(t, err, 0)
+
+	err = CheckDir(&synta, rootFS, "prove7", &Options{true, true, false, false})
 	assert.NotNil(t, err)
 }
 
 func TestWithoutDefinition(t *testing.T) {
-	err := CheckDir(nil, rootFS, "prove6", &Options{true, true, false})
-	assert.Nil(t, err)
+	err := CheckDir(nil, rootFS, "prove6", &Options{true, true, false, false})
+	assert.Len(t, err, 0)
 }

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,7 @@ import (
 type RegexMatchError struct {
 	Regexp   string
 	Filename string
+	Path     string
 }
 
 func (e RegexMatchError) Error() string {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/csunibo/synta v0.1.2
 	github.com/liamg/memoryfs v1.6.0
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/csunibo/synta v0.1.1 h1:zAX9mG2HwbmCGosVyNz6vydCy6ayHzV0t6B6gAR8g2I=
-github.com/csunibo/synta v0.1.1/go.mod h1:jT0+S6wQ3SXj4uEOq8Ht2OPbmHCx6qZaUPTPX+1KwTE=
 github.com/csunibo/synta v0.1.2 h1:47yJqPxa6sWP9/Pm43StlQwBHYjjv7sDhgdeqdu0t1g=
 github.com/csunibo/synta v0.1.2/go.mod h1:jT0+S6wQ3SXj4uEOq8Ht2OPbmHCx6qZaUPTPX+1KwTE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -10,8 +8,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Sarebbe carino poter vedere, senza aprire il log del workflow, quale file è problematico. Questa PR implementa proprio questo con:
- opzione `failfast` (di default false): se vera, il programma termina al primo errore trovato
- variabile di ambiente `GITHUB_ACTIONS`: di default è "true" nei worker dei workfloe